### PR TITLE
Union Types / Enum types

### DIFF
--- a/src/query-to-decoder.ts
+++ b/src/query-to-decoder.ts
@@ -282,7 +282,7 @@ export function decoderFor(def: OperationDefinition | FragmentDefinition, info: 
         let fields = walkSelectionSet(inlineFragment.selectionSet, info);
         info.leave(inlineFragment);
         let fieldNames = getSelectionSetFields(inlineFragment.selectionSet, info);
-        let ctor = elmSafeName((union_name+inlineFragment.typeCondition.name.value));
+        let ctor = elmSafeName((union_name+'_'+inlineFragment.typeCondition.name.value));
         let shape = `(\\${fieldNames.join(' ')} -> ${ctor} { ${fieldNames.map(f => f + ' = ' + f).join(', ')} })`;
         let right = '(map ' + shape + ' ' + fields.expr + ')';
         decoder += right;
@@ -303,7 +303,7 @@ export function decoderFor(def: OperationDefinition | FragmentDefinition, info: 
           let fields = walkSelectionSet(def.selectionSet, info);
           let fieldNames = getSelectionSetFields(def.selectionSet, info);
           info.leave(def)
-          let ctor = elmSafeName((union_name+name));
+          let ctor = elmSafeName((union_name+'_'+name));
           let shape = `(\\${fieldNames.join(' ')} -> ${ctor} { ${fieldNames.map(f => f + ' = ' + f).join(', ')} })`;
           let right = '(map ' + shape + ' ' + fields.expr + ')';
           decoder += right;

--- a/src/query-to-decoder.ts
+++ b/src/query-to-decoder.ts
@@ -208,7 +208,12 @@ export function decoderFor(def: OperationDefinition | FragmentDefinition, info: 
     
     if (info_type instanceof GraphQLUnionType) {
       // Union
-      return walkUnion(originalName, field, info);
+      let expr = walkUnion(originalName, field, info);
+
+      if (isMaybe) {
+        expr = { expr: '(' + 'maybe ' + expr.expr + ')'};
+      }
+      return expr;
     } else {
       // SelectionSet
       if (field.selectionSet) {
@@ -225,11 +230,11 @@ export function decoderFor(def: OperationDefinition | FragmentDefinition, info: 
         let right = '(map ' + shape + ' ' + fields.expr + '))';
         let indent = '        ';
         if (prefix) {
-	  right = '(' + prefix + right + ')';
-	}
-	if (isMaybe) {
-	  right = '(' + 'maybe ' + right + ')';
-	}
+	      right = '(' + prefix + right + ')';
+	    }
+	    if (isMaybe) {
+	      right = '(' + 'maybe ' + right + ')';
+	    }
 
         return { expr: left + indent + right };
       } else {
@@ -251,6 +256,13 @@ export function decoderFor(def: OperationDefinition | FragmentDefinition, info: 
     let decoder = '\n        (\\typename -> case typename of';
     let indent = '            ';
 
+    let union_type = info.getType();
+    let union_name = "";
+
+    if (union_type instanceof GraphQLUnionType) {
+      union_name = union_type.name;
+    }
+
     for (let sel of field.selectionSet.selections) {
       if (sel.kind == 'InlineFragment') {
         let inlineFragment = <InlineFragment> sel;
@@ -260,7 +272,7 @@ export function decoderFor(def: OperationDefinition | FragmentDefinition, info: 
         let fields = walkSelectionSet(inlineFragment.selectionSet, info);
         info.leave(inlineFragment);
         let fieldNames = getSelectionSetFields(inlineFragment.selectionSet, info);
-        let ctor = elmSafeName(inlineFragment.typeCondition.name.value);
+        let ctor = elmSafeName((union_name+inlineFragment.typeCondition.name.value));
         let shape = `(\\${fieldNames.join(' ')} -> ${ctor} { ${fieldNames.map(f => f + ' = ' + f).join(', ')} })`;
         let right = '(map ' + shape + ' ' + fields.expr + ')';
         decoder += right;
@@ -281,7 +293,7 @@ export function decoderFor(def: OperationDefinition | FragmentDefinition, info: 
           let fields = walkSelectionSet(def.selectionSet, info);
           let fieldNames = getSelectionSetFields(def.selectionSet, info);
           info.leave(def)
-          let ctor = elmSafeName(name);
+          let ctor = elmSafeName((union_name+name));
           let shape = `(\\${fieldNames.join(' ')} -> ${ctor} { ${fieldNames.map(f => f + ' = ' + f).join(', ')} })`;
           let right = '(map ' + shape + ' ' + fields.expr + ')';
           decoder += right;
@@ -292,7 +304,7 @@ export function decoderFor(def: OperationDefinition | FragmentDefinition, info: 
 
     decoder += `\n${indent}_ -> fail "Unexpected union type")`;
 
-    decoder = '((field "__typename" string) `andThen` ' + decoder + ')';
+    decoder = '((field "__typename" string) |> andThen ' + decoder + ')';
     return { expr: '(field "' + originalName + '" ' + decoder +')' };
   }
 

--- a/src/query-to-elm.ts
+++ b/src/query-to-elm.ts
@@ -130,7 +130,7 @@ function translateQuery(uri: string, doc: Document, schema: GraphQLSchema, verb:
     for (let name in seenUnions) {
       let union = seenUnions[name];
       decls = walkUnion(union, info).concat(decls);
-      expose.push(union.name+'(..)');
+      expose.push(name+'(..)');
     }
 
     return [decls, expose];
@@ -189,6 +189,9 @@ function translateQuery(uri: string, doc: Document, schema: GraphQLSchema, verb:
         if (node.kind == 'InlineFragment') {
           let parentType = <GraphQLUnionType> info.getType();
           if (parentType instanceof GraphQLNonNull) {
+            parentType = parentType['ofType']
+          }
+          if (parentType instanceof GraphQLList) {
             parentType = parentType['ofType']
           }
           unions[parentType.name] = parentType;
@@ -263,6 +266,9 @@ function translateQuery(uri: string, doc: Document, schema: GraphQLSchema, verb:
   function walkUnion(union: GraphQLUnionType, info: TypeInfo): Array<ElmDecl> {
     if (union instanceof GraphQLNonNull) {
       union = union['ofType'];
+    }
+    if (union instanceof GraphQLList) {
+        union = union['ofType']
     }
     let types = union.getTypes();
     // let params = types.map((t, i) => alphabet[i]).join(' ');
@@ -439,7 +445,12 @@ function translateQuery(uri: string, doc: Document, schema: GraphQLSchema, verb:
     let fields: Array<ElmFieldDecl> = [];
     let spreads: Array<string> = [];
     let info_type = info.getType();
+
     if (info_type instanceof GraphQLNonNull) {
+        info_type = info_type['ofType']
+    }
+
+    if (info_type instanceof GraphQLList) {
         info_type = info_type['ofType']
     }
 
@@ -471,6 +482,11 @@ function translateQuery(uri: string, doc: Document, schema: GraphQLSchema, verb:
       if (union instanceof GraphQLNonNull) {
           union = union['ofType']
       }
+
+      if (union instanceof GraphQLList) {
+          union = union['ofType']
+      }
+
       let typeMap: { [name: string]: ElmType } = {};
       for (let type of union.getTypes()) {
         typeMap[type.name] = new ElmTypeRecord([]);

--- a/src/query-to-elm.ts
+++ b/src/query-to-elm.ts
@@ -249,7 +249,7 @@ function translateQuery(uri: string, doc: Document, schema: GraphQLSchema, verb:
   }
 
   function walkEnum(enumType: GraphQLEnumType): ElmTypeDecl {
-    return new ElmTypeDecl(enumType.name, enumType.getValues().map(v => v.name[0].toUpperCase() + v.name.substr(1)));
+    return new ElmTypeDecl(enumType.name, enumType.getValues().map(v => enumType.name + v.name[0].toUpperCase() + v.name.substr(1).toLowerCase()));
   }
 
   function decoderForEnum(enumType: GraphQLEnumType): ElmFunctionDecl {
@@ -258,7 +258,7 @@ function translateQuery(uri: string, doc: Document, schema: GraphQLSchema, verb:
     return new ElmFunctionDecl(enumType.name.toLowerCase() + 'Decoder', [], new ElmTypeName('Decoder ' + decoderTypeName),
         { expr: 'string |> andThen (\\s ->\n' +
                 '        case s of\n' + enumType.getValues().map(v =>
-                '            "' + v.name + '" -> succeed ' + v.name[0].toUpperCase() + v.name.substr(1)).join('\n') + '\n' +
+                '            "' + v.name + '" -> succeed ' + decoderTypeName + v.name[0].toUpperCase() + v.name.substr(1).toLowerCase()).join('\n') + '\n' +
                 '            _ -> fail "Unknown ' + enumType.name + '")'
               });
   }

--- a/src/query-to-elm.ts
+++ b/src/query-to-elm.ts
@@ -274,11 +274,11 @@ function translateQuery(uri: string, doc: Document, schema: GraphQLSchema, verb:
     // let params = types.map((t, i) => alphabet[i]).join(' ');
     let decls: Array<ElmDecl> = [];
     for (let type of types) {
-        let name = union.name + type.name + 'Alias';
+        let name = union.name + '_' + type.name + '_';
         let t = typeToElm(type, true);
         decls.push(new ElmTypeAliasDecl(name, t))
     }
-    decls.push(new ElmTypeDecl(union.name + ' ', types.map((t, i) => elmSafeName(union.name+t.name) + ' ' + union.name + t.name + 'Alias')));
+    decls.push(new ElmTypeDecl(union.name + ' ', types.map((t, i) => elmSafeName(union.name+'_'+t.name) + ' ' + union.name + '_' + t.name + '_')));
     return decls;
   }
   

--- a/src/query-to-elm.ts
+++ b/src/query-to-elm.ts
@@ -249,7 +249,7 @@ function translateQuery(uri: string, doc: Document, schema: GraphQLSchema, verb:
   }
 
   function walkEnum(enumType: GraphQLEnumType): ElmTypeDecl {
-    return new ElmTypeDecl(enumType.name, enumType.getValues().map(v => enumType.name + v.name[0].toUpperCase() + v.name.substr(1).toLowerCase()));
+    return new ElmTypeDecl(enumType.name, enumType.getValues().map(v => enumType.name + '_' + v.name[0].toUpperCase() + v.name.substr(1).toLowerCase()));
   }
 
   function decoderForEnum(enumType: GraphQLEnumType): ElmFunctionDecl {
@@ -258,7 +258,7 @@ function translateQuery(uri: string, doc: Document, schema: GraphQLSchema, verb:
     return new ElmFunctionDecl(enumType.name.toLowerCase() + 'Decoder', [], new ElmTypeName('Decoder ' + decoderTypeName),
         { expr: 'string |> andThen (\\s ->\n' +
                 '        case s of\n' + enumType.getValues().map(v =>
-                '            "' + v.name + '" -> succeed ' + decoderTypeName + v.name[0].toUpperCase() + v.name.substr(1).toLowerCase()).join('\n') + '\n' +
+                '            "' + v.name + '" -> succeed ' + decoderTypeName + '_' + v.name[0].toUpperCase() + v.name.substr(1).toLowerCase()).join('\n') + '\n' +
                 '            _ -> fail "Unknown ' + enumType.name + '")'
               });
   }
@@ -403,7 +403,13 @@ function translateQuery(uri: string, doc: Document, schema: GraphQLSchema, verb:
         case 'DateTime': encoder = 'Json.Encode.string ' + value; break;
         case 'String': encoder = 'Json.Encode.string ' + value; break;
       }
+    } else if (type instanceof  GraphQLEnumType) {
+      const values = type.getValues()
+      const tuples = values.map((v) => `("${type.name + '_' + v.name[0].toUpperCase() + v.name.substr(1).toLowerCase()}", "${v.name}")`)
+      const map = `[${tuples.join(',')}]`
+      encoder = `Json.Encode.string <| Maybe.withDefault "" <| Maybe.map Tuple.second <| List.head <| (\\s -> List.filter (Tuple.first >> (==)(s)) ${map} ) <| toString ` + value;
     } else {
+
       throw new Error('not implemented: ' + type.constructor.name);
     }
 


### PR DESCRIPTION
Now generates union types...AND ENUM TYPES!

Given:

`query test {
  testUnion {
    __typename
    ... on UnionOne {
      id_one
    }
    ... on UnionTwo {
      id_two
    }
  }
}`


Generates:
```

type TestUnion
  = TestUnion_UnionOne TestUnion_UnionOne_
  | TestUnion_UnionTwo TestUnion_UnionTwo_

type alias TestUnion_UnionOne_ =
  { id_one : String
  }


type alias TestUnion_UnionTwo_ =
  { id_two : String
  }

type alias Test =
  { testUnion : Maybe TestUnion
  }

...

test : Http.Request Test
test =
  let
    graphQLQuery =
      """query test { testUnion { __typename ... on UnionOne { id_one } ... on UnionTwo { id_two } } }"""
  in
  let
    graphQLParams =
      Json.Encode.object
        []
  in
  GraphQL.query "GET" endpointUrl graphQLQuery "test" graphQLParams testDecoder


testDecoder : Decoder Test
testDecoder =
  map Test
    (maybe
      (field "testUnion"
        (field "__typename" string
          |> andThen
              (\typename ->
                case typename of
                  "UnionOne" ->
                    map (\id_one -> TestUnion_UnionOne { id_one = id_one }) (field "id_one" string)

                  "UnionTwo" ->
                    map (\id_two -> TestUnion_UnionTwo { id_two = id_two }) (field "id_two" string)

                  _ ->
                    fail "Unexpected union type"
              )
        )
      )
    )
```