### PR TITLE
Default custom scalars to strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influential/elm-graphql",
-  "version": "1.1.2",
+  "version": "1.5.0",
   "description": "Elm code generator for GraphQL",
   "main": "lib/main.js",
   "bin": "bin/elm-graphql",

--- a/src/query-to-decoder.ts
+++ b/src/query-to-decoder.ts
@@ -350,6 +350,7 @@ export function decoderFor(def: OperationDefinition | FragmentDefinition, info: 
         case 'ID':
         case 'DateTime': return 'string';
         case 'String': return 'string';
+        default: return 'string';
       }
     } else if (type instanceof GraphQLEnumType) {
       return type.name.toLowerCase() + 'Decoder';

--- a/src/query-to-elm.ts
+++ b/src/query-to-elm.ts
@@ -410,6 +410,7 @@ function translateQuery(uri: string, doc: Document, schema: GraphQLSchema, verb:
         case 'ID':
         case 'DateTime': encoder = 'Json.Encode.string ' + value; break;
         case 'String': encoder = 'Json.Encode.string ' + value; break;
+        default: encoder = 'Json.Encode.string ' + value; break;
       }
     } else if (type instanceof  GraphQLEnumType) {
       const values = type.getValues()
@@ -640,6 +641,7 @@ export function typeToElm(type: GraphQLType, isNonNull = false): ElmType {
       case 'ID':
       case 'DateTime': elmType = new ElmTypeName('String'); break;
       case 'String': elmType = new ElmTypeName('String'); break;
+      default: elmType = new ElmTypeName('String'); break;
     }
   } else if (type instanceof GraphQLEnumType) {
     elmType = new ElmTypeName(type.name[0].toUpperCase() + type.name.substr(1));


### PR DESCRIPTION
When encountering a custom scalar, default to a string for elm decoding.